### PR TITLE
Add credits to README and GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get version from manifest
+        id: version
+        run: |
+          VERSION=$(jq -r .version manifest.json)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check_tag
+        uses: mukunku/tag-exists-action@v1.4.0
+        with:
+          tag: 'v${{ steps.version.outputs.version }}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Git Tag
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag v${{ steps.version.outputs.version }}
+          git push origin v${{ steps.version.outputs.version }}
+
+      - name: Zip extension
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          zip -r extension.zip . -x "*.git*" ".github/*"
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          files: extension.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to Chrome Web Store
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: mnao305/chrome-extension-upload@v4.0.1
+        with:
+          file-path: extension.zip
+          extension-id: ${{ secrets.CHROME_EXTENSION_ID }}
+          client-id: ${{ secrets.CHROME_CLIENT_ID }}
+          client-secret: ${{ secrets.CHROME_CLIENT_SECRET }}
+          refresh-token: ${{ secrets.CHROME_REFRESH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Once installed and enabled, the extension will automatically add formatting capa
 
 The extension relies on a minified version of the `sql-formatter` package located at `libs/sql-formatter.min.js`.
 
+## Credits
+
+This project uses and is inspired by the following open-source projects:
+
+- [Adminer](https://github.com/vrana/adminer) (v4.8.1)
+- [SQL Formatter](https://github.com/sql-formatter-org/sql-formatter) (v15.3.0)
+
 ## License
 
 MIT License


### PR DESCRIPTION
Thêm phần ghi công vào `README.md` với liên kết đến các kho lưu trữ Adminer và SQL Formatter cùng với phiên bản hiện tại của chúng.
Tạo một quy trình làm việc GitHub Actions (`.github/workflows/release.yml`) tự động hóa việc phát hành. Quy trình này sẽ kích hoạt khi có thay đổi trên nhánh `main`, trích xuất phiên bản từ `manifest.json`, đẩy tag git nếu tag chưa tồn tại, tạo GitHub Release và xuất bản tiện ích mở rộng lên Chrome Web Store.

---
*PR created automatically by Jules for task [14204961978469772611](https://jules.google.com/task/14204961978469772611) started by @lelinhtinh*